### PR TITLE
Fix Public Path

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -11,7 +11,7 @@
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Alfa+Slab+One|Roboto+Slab" rel="stylesheet">
-    <link rel="stylesheet" href="/public/css/styles.css">
+    <link rel="stylesheet" href="/css/styles.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ var corsOption = {
   exposedHeaders: ['x-auth-token']
 };
 app.use(cors(corsOption));
-// app.use(express.static(path.join(__dirname, 'client/build')));
+app.use(express.static(path.join(__dirname, 'client/public')));
 app.use(cookieParser());
 // app.use(methodOverride());
 app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
I've had a look at this and it seems like you had the static middleware commented out.

I've changed it so that the route is `client/public/`. What this means is that any request that hits your server, will check the path eg `/css/styles.css` and see if it can find a file in `client/public/css/styles.css`. If it finds it, that file will be server otherwise the request will move further into your app.

Hope that helps!